### PR TITLE
인물 합치기 완료 후 뒤로가기 시 빈 화면이 노출되는 이슈를 해결한다

### DIFF
--- a/feature/detail/src/main/java/com/example/metasearch/feature/detail/person/PersonDetailPresenter.kt
+++ b/feature/detail/src/main/java/com/example/metasearch/feature/detail/person/PersonDetailPresenter.kt
@@ -1,6 +1,7 @@
 package com.example.metasearch.feature.detail.person
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
@@ -61,6 +62,16 @@ class PersonDetailPresenter @AssistedInject constructor(
         var editRepresentativeFaceId by rememberRetained { mutableStateOf<Long?>(null) }
         var showMergeConfirmDialog by rememberRetained { mutableStateOf(false) }
         var showPhotoSelectDialog by rememberRetained { mutableStateOf(false) }
+
+        var isInitialized by remember { mutableStateOf(false) }
+
+        LaunchedEffect(person) {
+            if (person != null) {
+                isInitialized = true
+            } else if (isInitialized && !isLoading) {
+                navigator.pop()
+            }
+        }
 
         suspend fun savePersonInfo() {
             val currentPerson = person ?: return


### PR DESCRIPTION
isInitialized 플래그 도입

## 테스트 영상
<img src="https://github.com/user-attachments/assets/0c282e27-3080-4b86-bf83-fec2e0cfe50a" width="300" />