### PR TITLE
fix: State loss in search screen during backstack restoration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,7 @@ constraintlayoutCompose = "1.1.1"
 coilCompose = "3.3.0"
 
 ## Circuit
-circuit = "0.31.0"
+circuit = "0.32.0"
 
 ## Hilt
 hilt = "2.57.2"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Circuit dependency to the latest version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description
This PR addresses a state loss bug occurring during back navigation from the PhotoDetail screen.

## Technical Details
• Upgraded Circuit to v0.32.0.
• This update includes a fix for the rememberRetained state resetting issue previously reported in the library.
### Reference
• [slackhq/circuit#2477](https://github.com/slackhq/circuit/issues/2477)

## Check
<div align="center">
<h6>Search results preserved</h6>
<img src="https://github.com/user-attachments/assets/cd149eb6-4d22-437f-a89e-39d7e515d2f1" width="200" />
</div>