### PR TITLE
refactor: Extract WebViewErrorUi to core:ui:component

### DIFF
--- a/core/ui/src/main/java/com/metasearch/android/core/ui/component/WebViewErrorUi.kt
+++ b/core/ui/src/main/java/com/metasearch/android/core/ui/component/WebViewErrorUi.kt
@@ -1,4 +1,4 @@
-package com.metasearch.android.feature.detail.graph.component
+package com.metasearch.android.core.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -16,7 +16,7 @@ import com.metasearch.android.core.designsystem.annotation.ComponentPreview
 import com.metasearch.android.core.designsystem.component.MetaSearchButton
 import com.metasearch.android.core.designsystem.theme.MetaSearchTheme
 import com.metasearch.android.core.designsystem.theme.White
-import com.metasearch.android.feature.detail.R
+import com.metasearch.android.core.ui.R
 
 @Composable
 fun WebViewErrorUi(
@@ -28,13 +28,13 @@ fun WebViewErrorUi(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = stringResource(R.string.graph_detail_screen_webview_error),
+            text = stringResource(R.string.webview_error_description),
             style = MetaSearchTheme.typography.bodyMedium,
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(MetaSearchTheme.spacing.spacing4))
         MetaSearchButton(
-            text = stringResource(R.string.graph_detail_screen_reload_text_button),
+            text = stringResource(R.string.webview_reload_text_button),
             onClick = onRetryClick,
         )
     }

--- a/core/ui/src/main/res/values-en/strings.xml
+++ b/core/ui/src/main/res/values-en/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="webview_error_description">Server connection failed.</string>
+    <string name="webview_reload_text_button">Try again</string>
+</resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="webview_error_description">서버 연결에 실패했습니다.</string>
+    <string name="webview_reload_text_button">다시 시도</string>
+</resources>

--- a/core/ui/stability/ui.stability
+++ b/core/ui/stability/ui.stability
@@ -5,73 +5,7 @@
 //   ./gradlew :ui:stabilityDump
 
 @Composable
-public fun com.metasearch.android.core.ui.MetaSearchScaffold(modifier: androidx.compose.ui.Modifier, topBar: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, bottomBar: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, snackbarHost: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, floatingActionButton: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, containerColor: androidx.compose.ui.graphics.Color, contentWindowInsets: androidx.compose.foundation.layout.WindowInsets, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.PaddingValues, kotlin.Unit>): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-    - modifier: STABLE (marked @Stable or @Immutable)
-    - topBar: STABLE (composable function type)
-    - bottomBar: STABLE (composable function type)
-    - snackbarHost: STABLE (composable function type)
-    - floatingActionButton: STABLE (composable function type)
-    - containerColor: STABLE (marked @Stable or @Immutable)
-    - contentWindowInsets: STABLE (marked @Stable or @Immutable)
-    - content: STABLE (composable function type)
-
-@Composable
 private fun com.metasearch.android.core.ui.component.FocusingSearchHeaderPreview(): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-
-@Composable
-public fun com.metasearch.android.core.ui.component.MetaSearchCircleImage(modifier: androidx.compose.ui.Modifier, model: kotlin.Any?, contentDescription: kotlin.String?, size: androidx.compose.ui.unit.Dp, borderWidth: androidx.compose.ui.unit.Dp, borderColor: androidx.compose.ui.graphics.Color, onClick: kotlin.Function0<kotlin.Unit>?): kotlin.Unit
-  skippable: false
-  restartable: true
-  params:
-    - modifier: STABLE (marked @Stable or @Immutable)
-    - model: UNSTABLE (has mutable properties or unstable members)
-    - contentDescription: STABLE (class with no mutable properties)
-    - size: STABLE (marked @Stable or @Immutable)
-    - borderWidth: STABLE (marked @Stable or @Immutable)
-    - borderColor: STABLE (marked @Stable or @Immutable)
-    - onClick: STABLE (function type)
-
-@Composable
-private fun com.metasearch.android.core.ui.component.MetaSearchCircleImagePreview(): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-
-@Composable
-public fun com.metasearch.android.core.ui.component.MetaSearchDialog(modifier: androidx.compose.ui.Modifier, onDismissRequest: kotlin.Function0<kotlin.Unit>, onConfirmRequest: kotlin.Function0<kotlin.Unit>, dismissButtonText: kotlin.String?, confirmButtonText: kotlin.String, title: kotlin.String?, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>?, properties: androidx.compose.ui.window.DialogProperties): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-    - modifier: STABLE (marked @Stable or @Immutable)
-    - onDismissRequest: STABLE (function type)
-    - onConfirmRequest: STABLE (function type)
-    - dismissButtonText: STABLE (class with no mutable properties)
-    - confirmButtonText: STABLE (String is immutable)
-    - title: STABLE (class with no mutable properties)
-    - content: STABLE (composable function type)
-    - properties: STABLE (marked @Stable or @Immutable)
-
-@Composable
-private fun com.metasearch.android.core.ui.component.MetaSearchDialogPreview(): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-
-@Composable
-public fun com.metasearch.android.core.ui.component.MetaSearchDivider(modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-    - modifier: STABLE (marked @Stable or @Immutable)
-
-@Composable
-private fun com.metasearch.android.core.ui.component.MetaSearchDividerPreview(): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -86,19 +20,6 @@ public fun com.metasearch.android.core.ui.component.MetaSearchHeader(modifier: a
     - onBackClick: STABLE (function type)
     - textStyle: STABLE (marked @Stable or @Immutable)
     - textAlign: STABLE (known stable type)
-
-@Composable
-public fun com.metasearch.android.core.ui.component.MetaSearchLoadingIndicator(modifier: androidx.compose.ui.Modifier): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-    - modifier: STABLE (marked @Stable or @Immutable)
-
-@Composable
-private fun com.metasearch.android.core.ui.component.MetaSearchLoadingIndicatorPreview(): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
 
 @Composable
 public fun com.metasearch.android.core.ui.component.MetaSearchSearchBar(modifier: androidx.compose.ui.Modifier, value: kotlin.String, onValueChange: kotlin.Function1<kotlin.String, kotlin.Unit>, onSearchClick: kotlin.Function0<kotlin.Unit>, placeholder: kotlin.String): kotlin.Unit
@@ -118,18 +39,14 @@ private fun com.metasearch.android.core.ui.component.MetaSearchSearchBarPreview(
   params:
 
 @Composable
-public fun com.metasearch.android.core.ui.component.MetaSearchSquareImage(modifier: androidx.compose.ui.Modifier, model: kotlin.Any?, contentDescription: kotlin.String?, onClick: kotlin.Function0<kotlin.Unit>?, onLongClick: kotlin.Function0<kotlin.Unit>?): kotlin.Unit
-  skippable: false
+public fun com.metasearch.android.core.ui.component.WebViewErrorUi(onRetryClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+  skippable: true
   restartable: true
   params:
-    - modifier: STABLE (marked @Stable or @Immutable)
-    - model: UNSTABLE (has mutable properties or unstable members)
-    - contentDescription: STABLE (class with no mutable properties)
-    - onClick: STABLE (function type)
-    - onLongClick: STABLE (function type)
+    - onRetryClick: STABLE (function type)
 
 @Composable
-private fun com.metasearch.android.core.ui.component.MetaSearchSquareImagePreview(): kotlin.Unit
+private fun com.metasearch.android.core.ui.component.WebViewErrorUiPreview(): kotlin.Unit
   skippable: true
   restartable: true
   params:

--- a/core/ui/stability/ui.stability
+++ b/core/ui/stability/ui.stability
@@ -5,7 +5,73 @@
 //   ./gradlew :ui:stabilityDump
 
 @Composable
+public fun com.metasearch.android.core.ui.MetaSearchScaffold(modifier: androidx.compose.ui.Modifier, topBar: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, bottomBar: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, snackbarHost: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, floatingActionButton: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>, containerColor: androidx.compose.ui.graphics.Color, contentWindowInsets: androidx.compose.foundation.layout.WindowInsets, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction1<androidx.compose.foundation.layout.PaddingValues, kotlin.Unit>): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - topBar: STABLE (composable function type)
+    - bottomBar: STABLE (composable function type)
+    - snackbarHost: STABLE (composable function type)
+    - floatingActionButton: STABLE (composable function type)
+    - containerColor: STABLE (marked @Stable or @Immutable)
+    - contentWindowInsets: STABLE (marked @Stable or @Immutable)
+    - content: STABLE (composable function type)
+
+@Composable
 private fun com.metasearch.android.core.ui.component.FocusingSearchHeaderPreview(): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.metasearch.android.core.ui.component.MetaSearchCircleImage(modifier: androidx.compose.ui.Modifier, model: kotlin.Any?, contentDescription: kotlin.String?, size: androidx.compose.ui.unit.Dp, borderWidth: androidx.compose.ui.unit.Dp, borderColor: androidx.compose.ui.graphics.Color, onClick: kotlin.Function0<kotlin.Unit>?): kotlin.Unit
+  skippable: false
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - model: UNSTABLE (has mutable properties or unstable members)
+    - contentDescription: STABLE (class with no mutable properties)
+    - size: STABLE (marked @Stable or @Immutable)
+    - borderWidth: STABLE (marked @Stable or @Immutable)
+    - borderColor: STABLE (marked @Stable or @Immutable)
+    - onClick: STABLE (function type)
+
+@Composable
+private fun com.metasearch.android.core.ui.component.MetaSearchCircleImagePreview(): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.metasearch.android.core.ui.component.MetaSearchDialog(modifier: androidx.compose.ui.Modifier, onDismissRequest: kotlin.Function0<kotlin.Unit>, onConfirmRequest: kotlin.Function0<kotlin.Unit>, dismissButtonText: kotlin.String?, confirmButtonText: kotlin.String, title: kotlin.String?, content: @[Composable] androidx.compose.runtime.internal.ComposableFunction0<kotlin.Unit>?, properties: androidx.compose.ui.window.DialogProperties): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - onDismissRequest: STABLE (function type)
+    - onConfirmRequest: STABLE (function type)
+    - dismissButtonText: STABLE (class with no mutable properties)
+    - confirmButtonText: STABLE (String is immutable)
+    - title: STABLE (class with no mutable properties)
+    - content: STABLE (composable function type)
+    - properties: STABLE (marked @Stable or @Immutable)
+
+@Composable
+private fun com.metasearch.android.core.ui.component.MetaSearchDialogPreview(): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.metasearch.android.core.ui.component.MetaSearchDivider(modifier: androidx.compose.ui.Modifier): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+private fun com.metasearch.android.core.ui.component.MetaSearchDividerPreview(): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -22,6 +88,19 @@ public fun com.metasearch.android.core.ui.component.MetaSearchHeader(modifier: a
     - textAlign: STABLE (known stable type)
 
 @Composable
+public fun com.metasearch.android.core.ui.component.MetaSearchLoadingIndicator(modifier: androidx.compose.ui.Modifier): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
+private fun com.metasearch.android.core.ui.component.MetaSearchLoadingIndicatorPreview(): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
 public fun com.metasearch.android.core.ui.component.MetaSearchSearchBar(modifier: androidx.compose.ui.Modifier, value: kotlin.String, onValueChange: kotlin.Function1<kotlin.String, kotlin.Unit>, onSearchClick: kotlin.Function0<kotlin.Unit>, placeholder: kotlin.String): kotlin.Unit
   skippable: true
   restartable: true
@@ -34,6 +113,23 @@ public fun com.metasearch.android.core.ui.component.MetaSearchSearchBar(modifier
 
 @Composable
 private fun com.metasearch.android.core.ui.component.MetaSearchSearchBarPreview(): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+
+@Composable
+public fun com.metasearch.android.core.ui.component.MetaSearchSquareImage(modifier: androidx.compose.ui.Modifier, model: kotlin.Any?, contentDescription: kotlin.String?, onClick: kotlin.Function0<kotlin.Unit>?, onLongClick: kotlin.Function0<kotlin.Unit>?): kotlin.Unit
+  skippable: false
+  restartable: true
+  params:
+    - modifier: STABLE (marked @Stable or @Immutable)
+    - model: UNSTABLE (has mutable properties or unstable members)
+    - contentDescription: STABLE (class with no mutable properties)
+    - onClick: STABLE (function type)
+    - onLongClick: STABLE (function type)
+
+@Composable
+private fun com.metasearch.android.core.ui.component.MetaSearchSquareImagePreview(): kotlin.Unit
   skippable: true
   restartable: true
   params:

--- a/feature/detail/src/main/java/com/metasearch/android/feature/detail/graph/GraphDetailUi.kt
+++ b/feature/detail/src/main/java/com/metasearch/android/feature/detail/graph/GraphDetailUi.kt
@@ -24,11 +24,11 @@ import com.metasearch.android.core.designsystem.theme.White
 import com.metasearch.android.core.ui.MetaSearchScaffold
 import com.metasearch.android.core.ui.component.MetaSearchHeader
 import com.metasearch.android.core.ui.component.MetaSearchLoadingIndicator
+import com.metasearch.android.core.ui.component.WebViewErrorUi
 import com.metasearch.android.core.webview.ui.MetaSearchWebViewClient
 import com.metasearch.android.core.webview.ui.MetaSearchWebViewContainer
 import com.metasearch.android.feature.detail.R
 import com.metasearch.android.feature.detail.graph.component.ExploreImageList
-import com.metasearch.android.feature.detail.graph.component.WebViewErrorUi
 import com.metasearch.android.feature.detail.graph.mock.graphDetailUiStateMock
 import com.metasearch.android.feature.screens.GraphDetailScreen
 import com.slack.circuit.codegen.annotations.CircuitInject

--- a/feature/detail/src/main/res/values-en/strings.xml
+++ b/feature/detail/src/main/res/values-en/strings.xml
@@ -19,8 +19,6 @@
     <string name="graph_detail_screen_error">No photos found.</string>
     <string name="graph_detail_screen_dialog_title">NOTE</string>
     <string name="graph_detail_screen_dialog_close_button">OK</string>
-    <string name="graph_detail_screen_webview_error">Server connection failed.</string>
-    <string name="graph_detail_screen_reload_text_button">Try again</string>
 
     <string name="photo_detail_screen_header">Visualize Me By Photo</string>
     <string name="photo_detail_screen_bottom_item_openai">Description</string>

--- a/feature/detail/src/main/res/values/strings.xml
+++ b/feature/detail/src/main/res/values/strings.xml
@@ -20,8 +20,6 @@
     <string name="graph_detail_screen_error">사진을 찾지 못했습니다.</string>
     <string name="graph_detail_screen_dialog_title">알림</string>
     <string name="graph_detail_screen_dialog_close_button">확인</string>
-    <string name="graph_detail_screen_webview_error">서버 연결에 실패했습니다.</string>
-    <string name="graph_detail_screen_reload_text_button">다시 시도</string>
 
     <string name="photo_detail_screen_header">Visualize Me By Photo</string>
     <string name="photo_detail_screen_bottom_item_openai">설명</string>

--- a/feature/detail/stability/detail.stability
+++ b/feature/detail/stability/detail.stability
@@ -54,19 +54,6 @@ public fun com.metasearch.android.feature.detail.graph.component.ExploreImageLis
   params:
 
 @Composable
-public fun com.metasearch.android.feature.detail.graph.component.WebViewErrorUi(onRetryClick: kotlin.Function0<kotlin.Unit>): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-    - onRetryClick: STABLE (function type)
-
-@Composable
-private fun com.metasearch.android.feature.detail.graph.component.WebViewErrorUiPreview(): kotlin.Unit
-  skippable: true
-  restartable: true
-  params:
-
-@Composable
 private fun com.metasearch.android.feature.detail.person.PersonDetailContent(innerPadding: androidx.compose.foundation.layout.PaddingValues, state: com.metasearch.android.feature.detail.person.PersonDetailUiState): kotlin.Unit
   skippable: true
   restartable: true

--- a/feature/graph/src/main/java/com/metasearch/android/feature/graph/GraphUi.kt
+++ b/feature/graph/src/main/java/com/metasearch/android/feature/graph/GraphUi.kt
@@ -33,13 +33,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import coil3.compose.AsyncImage
 import com.metasearch.android.core.designsystem.annotation.DevicePreview
-import com.metasearch.android.core.designsystem.component.MetaSearchButton
 import com.metasearch.android.core.designsystem.theme.MetaSearchTheme
 import com.metasearch.android.core.designsystem.theme.Neutral500
 import com.metasearch.android.core.designsystem.theme.White
 import com.metasearch.android.core.ui.MetaSearchScaffold
 import com.metasearch.android.core.ui.component.MetaSearchHeader
 import com.metasearch.android.core.ui.component.MetaSearchLoadingIndicator
+import com.metasearch.android.core.ui.component.WebViewErrorUi
 import com.metasearch.android.core.webview.ui.MetaSearchWebViewClient
 import com.metasearch.android.core.webview.ui.MetaSearchWebViewContainer
 import com.metasearch.android.feature.graph.mock.graphUiStateMock
@@ -149,22 +149,7 @@ private fun GraphUiContent(
             }
 
             if (state.uiState is UiState.Error) {
-                Column(
-                    modifier = Modifier.fillMaxSize().background(White),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = stringResource(R.string.graph_screen_network_error),
-                        style = MetaSearchTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center,
-                    )
-                    Spacer(modifier = Modifier.height(MetaSearchTheme.spacing.spacing4))
-                    MetaSearchButton(
-                        text = stringResource(R.string.graph_screen_reload_text_button),
-                        onClick = { state.eventSink(GraphUiEvent.OnRetry) },
-                    )
-                }
+                WebViewErrorUi(onRetryClick = { state.eventSink(GraphUiEvent.OnRetry) })
             }
         }
 

--- a/feature/graph/src/main/res/values-en/strings.xml
+++ b/feature/graph/src/main/res/values-en/strings.xml
@@ -3,7 +3,5 @@
     <string name="graph_screen_bottom_selected_image_label">Navigation images</string>
     <string name="graph_screen_dialog_close_button">OK</string>
     <string name="graph_screen_dialog_title">NOTE</string>
-    <string name="graph_screen_network_error">Server connection failed.</string>
-    <string name="graph_screen_reload_text_button">Retry</string>
     <string name="graph_screen_image_not_found_error">No photos found.</string>
 </resources>

--- a/feature/graph/src/main/res/values/strings.xml
+++ b/feature/graph/src/main/res/values/strings.xml
@@ -4,7 +4,5 @@
     <string name="graph_screen_bottom_selected_image_label">탐색 이미지</string>
     <string name="graph_screen_dialog_close_button">확인</string>
     <string name="graph_screen_dialog_title">알림</string>
-    <string name="graph_screen_network_error">서버 연결에 실패했습니다.</string>
-    <string name="graph_screen_reload_text_button">다시 시도</string>
     <string name="graph_screen_image_not_found_error">사진을 찾지 못했습니다.</string>
 </resources>


### PR DESCRIPTION
## Related issue
- closed #118 

## Work Description ✏️

- Standardized the error state visualization for all WebView-based features using a single source of truth.

## Screenshot 📸

| WebView Error (New Component) | Normal Operation (Existing) |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/d62761ae-91d8-4690-9b59-e888745c38dc" width="180"/> | <img src="https://github.com/user-attachments/assets/261bae0b-579b-4a32-b8dd-4284e3659d50" width="180"/> |

> Confirmed that the existing WebView content still loads correctly after the refactoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * WebView error UI moved into the shared core and standardized so screens use a single, consistent error view with a retry action.
* **Localization**
  * English and Korean strings for the WebView error message ("Server connection failed." / "서버 연결에 실패했습니다.") and retry button ("Try again" / "다시 시도") were centralized and replaced local duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->