### PR TITLE
fix(home): Remove duplicated PartialAccessBanner component

### DIFF
--- a/feature/home/src/main/java/com/metasearch/android/feature/home/HomeUi.kt
+++ b/feature/home/src/main/java/com/metasearch/android/feature/home/HomeUi.kt
@@ -106,14 +106,6 @@ fun HomeUi(
             )
         }
 
-        if (!permissionState.allPermissionsGranted && permissionState.canProceed) {
-            PartialAccessBanner(
-                onClick = {
-                    permissionState.launchSystemRequest()
-                },
-            )
-        }
-
         AnimatedVisibility(
             visible = state.selectedLongClickImage != null,
             modifier = Modifier.zIndex(5f),


### PR DESCRIPTION
## Related issue
- closed #issue_number

## Work Description ✏️
Removed duplicated components.

## Screenshot 📸
<img src="" width="180"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* ~~**Style**~~
  * ~~Updated the permission access banner styling to display as a full-width semi-transparent banner for improved visibility on the home screen.~~

<!-- end of auto-generated comment: release notes by coderabbit.ai -->