### PR TITLE
refactor: Add local data check before person sync

### DIFF
--- a/data/person/impl/src/main/java/com/metasearch/android/data/person/impl/usecase/GetHomeDisplayPersonsUseCaseImpl.kt
+++ b/data/person/impl/src/main/java/com/metasearch/android/data/person/impl/usecase/GetHomeDisplayPersonsUseCaseImpl.kt
@@ -30,6 +30,10 @@ class GetHomeDisplayPersonsUseCaseImpl(
     }
 
     override suspend fun syncAndGet(currentList: List<Person>): List<Person> {
+        if (currentList.isEmpty() || personRepository.getPersonCount() == 0) {
+            return normalizeScores(currentList)
+        }
+
         val frequencies = personRepository.fetchPhotoFrequencies(currentList.map { it.inputName })
             .getOrElse { return normalizeScores(currentList) }
             .associate { it.personName to it.frequency }


### PR DESCRIPTION
## Related issue
- closed #161 

## Work Description ✏️
Skip remote sync if no persons are in local DB.

## Screenshot 📸
<img src="" width="180"/>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Optimized home display loading to skip unnecessary processing when no persons are available, improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->