### PR TITLE
feat: Add automated Compose preview screenshot testing with Roborazzi scanner

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.ksp.gradle.plugin)
     compileOnly(libs.compose.compiler.gradle.plugin)
+    compileOnly(libs.roborazzi.gradle.plugin)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 

--- a/build-logic/src/main/java/AndroidRoborazziConventionPlugin.kt
+++ b/build-logic/src/main/java/AndroidRoborazziConventionPlugin.kt
@@ -1,14 +1,29 @@
 import com.android.build.gradle.BaseExtension
 import com.metasearch.android.convention.Plugins
+import com.metasearch.android.convention.libs
+import com.metasearch.android.convention.testImplementation
+import com.metasearch.android.convention.testImplementationProject
+import io.github.takahirom.roborazzi.RoborazziExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
 
 internal class AndroidRoborazziConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             pluginManager.run {
                 apply(Plugins.ROBORAZZI)
+            }
+
+            extensions.configure<RoborazziExtension> {
+                generateComposePreviewRobolectricTests {
+                    enable.set(true)
+                    packages.set(listOf("com.metasearch.android"))
+                    includePrivatePreviews.set(true)
+                    useScanOptionParametersInTester.set(true)
+                    testerQualifiedClassName.set("com.metasearch.android.core.testing.previewtester.MetaSearchPreviewTester")
+                }
             }
 
             extensions.configure<BaseExtension> {
@@ -18,6 +33,14 @@ internal class AndroidRoborazziConventionPlugin : Plugin<Project> {
                         it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
                     }
                 }
+            }
+
+            dependencies {
+                testImplementation(libs.robolectric)
+                testImplementationProject(":core:testing")
+                testImplementation(libs.junit)
+                testImplementation(libs.roborazzi.preview.scanner.support)
+                testImplementation(libs.composable.preview.scanner)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
 val excludeModules: String? by project
 
 allprojects {
-    val skipQualityModules = listOf(":core:testing")
+    val skipQualityModules = listOf("")
 
     val isExcludedByProperty = excludeModules?.split(",")?.contains(project.name) == true
     val isSkippedModule = skipQualityModules.contains(project.path)

--- a/core/designsystem/src/main/java/com/metasearch/android/core/designsystem/component/MetaSearchTextField.kt
+++ b/core/designsystem/src/main/java/com/metasearch/android/core/designsystem/component/MetaSearchTextField.kt
@@ -1,5 +1,6 @@
 package com.metasearch.android.core.designsystem.component
 
+import android.os.Build
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
@@ -7,6 +8,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.metasearch.android.core.designsystem.annotation.ComponentPreview
 import com.metasearch.android.core.designsystem.theme.LightPink
 import com.metasearch.android.core.designsystem.theme.MetaSearchTheme
@@ -21,6 +23,8 @@ fun MetaSearchTextField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     singleLine: Boolean = true,
 ) {
+    val isRobolectric = Build.FINGERPRINT.contains("robolectric", ignoreCase = true)
+
     OutlinedTextField(
         value = value,
         onValueChange = onValueChange,
@@ -33,6 +37,7 @@ fun MetaSearchTextField(
             focusedBorderColor = Rose,
             unfocusedBorderColor = LightPink,
             focusedLabelColor = Rose,
+            cursorColor = if (isRobolectric) Color.Transparent else Rose,
         ),
     )
 }

--- a/core/designsystem/src/main/java/com/metasearch/android/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/metasearch/android/core/designsystem/theme/Theme.kt
@@ -13,9 +13,12 @@ private val LocalTypography = staticCompositionLocalOf { MetaSearchTypography() 
 
 @Composable
 fun MetaSearchTheme(content: @Composable () -> Unit) {
-    CompositionLocalProvider(
-        content = content,
-    )
+    CompositionLocalProvider {
+        androidx.compose.material3.Surface(
+            color = Neutral50,
+            content = content,
+        )
+    }
 }
 
 object MetaSearchTheme {

--- a/core/designsystem/src/main/java/com/metasearch/android/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/metasearch/android/core/designsystem/theme/Theme.kt
@@ -1,5 +1,6 @@
 package com.metasearch.android.core.designsystem.theme
 
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
@@ -14,7 +15,7 @@ private val LocalTypography = staticCompositionLocalOf { MetaSearchTypography() 
 @Composable
 fun MetaSearchTheme(content: @Composable () -> Unit) {
     CompositionLocalProvider {
-        androidx.compose.material3.Surface(
+        Surface(
             color = Neutral50,
             content = content,
         )

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.metasearch.android.library)
     alias(libs.plugins.roborazzi)
+    alias(libs.plugins.kotlin.compose)
 }
 
 android {
@@ -8,6 +9,10 @@ android {
 }
 
 dependencies {
+    api(libs.androidx.compose.runtime)
+    api(libs.androidx.compose.ui)
+    api(libs.androidx.compose.ui.tooling.preview)
+
     // Robolectric & JUnit
     api(libs.junit)
     api(libs.robolectric)
@@ -20,6 +25,9 @@ dependencies {
     // ScreenShot Test
     api(libs.roborazzi)
     api(libs.roborazzi.compose)
+
+    api(libs.roborazzi.preview.scanner.support)
+    api(libs.composable.preview.scanner)
 
     implementation(libs.coil.test)
     implementation(libs.coil.compose)

--- a/core/testing/src/main/java/com/metasearch/android/core/testing/previewtester/MetaSearchPreviewTester.kt
+++ b/core/testing/src/main/java/com/metasearch/android/core/testing/previewtester/MetaSearchPreviewTester.kt
@@ -1,0 +1,65 @@
+package com.metasearch.android.core.testing.previewtester
+
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.ComposePreviewTester
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.captureRoboImage
+import com.github.takahirom.roborazzi.name
+import com.metasearch.android.core.testing.rule.CoilRule
+import org.junit.rules.RuleChain
+import sergio.sastre.composable.preview.scanner.android.AndroidComposablePreviewScanner
+import sergio.sastre.composable.preview.scanner.android.AndroidPreviewInfo
+
+@OptIn(ExperimentalRoborazziApi::class)
+class MetaSearchPreviewTester :
+    ComposePreviewTester<ComposePreviewTester.TestParameter.JUnit4TestParameter<AndroidPreviewInfo>> {
+
+    override fun test(testParameter: ComposePreviewTester.TestParameter.JUnit4TestParameter<AndroidPreviewInfo>) {
+        val preview = testParameter.preview
+
+        println("Capture Preview: ${preview.declaringClass.name} - ${preview.methodName}")
+
+        try {
+            testParameter.composeTestRule.setContent {
+                preview()
+            }
+
+            testParameter.composeTestRule
+                .onRoot()
+                .captureRoboImage("${preview.declaringClass.name}_${preview.methodName}.png")
+        } catch (e: Exception) {
+            println("Error ${preview.methodName}: ${e.message}")
+        }
+    }
+
+    @Suppress("SpreadOperator")
+    override fun testParameters(): List<ComposePreviewTester.TestParameter.JUnit4TestParameter<AndroidPreviewInfo>> {
+        val options = options()
+        return AndroidComposablePreviewScanner()
+            .scanPackageTrees(*options.scanOptions.packages.toTypedArray())
+            .let { scanner ->
+                if (options.scanOptions.includePrivatePreviews) {
+                    scanner.includePrivatePreviews()
+                } else {
+                    scanner
+                }
+            }
+            .getPreviews()
+            .map { previewItem ->
+                ComposePreviewTester.TestParameter.JUnit4TestParameter(
+                    composeTestRuleFactory = (
+                        options.testLifecycleOptions as ComposePreviewTester.Options.JUnit4TestLifecycleOptions
+                        ).composeRuleFactory,
+                    preview = previewItem,
+                )
+            }
+    }
+
+    override fun options(): ComposePreviewTester.Options = super.options().copy(
+        testLifecycleOptions = ComposePreviewTester.Options.JUnit4TestLifecycleOptions(
+            testRuleFactory = { composeTestRule ->
+                RuleChain.outerRule(CoilRule()).around(composeTestRule)
+            },
+        ),
+    )
+}

--- a/core/testing/src/main/java/com/metasearch/android/core/testing/previewtester/MetaSearchPreviewTester.kt
+++ b/core/testing/src/main/java/com/metasearch/android/core/testing/previewtester/MetaSearchPreviewTester.kt
@@ -29,6 +29,7 @@ class MetaSearchPreviewTester :
                 .captureRoboImage("${preview.declaringClass.name}_${preview.methodName}.png")
         } catch (e: Exception) {
             println("Error ${preview.methodName}: ${e.message}")
+            throw e
         }
     }
 

--- a/core/ui/src/main/java/com/metasearch/android/core/ui/component/MetaSearchDialog.kt
+++ b/core/ui/src/main/java/com/metasearch/android/core/ui/component/MetaSearchDialog.kt
@@ -1,5 +1,6 @@
 package com.metasearch.android.core.ui.component
 
+import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -37,29 +39,20 @@ fun MetaSearchDialog(
     content: @Composable (() -> Unit)? = null,
     properties: DialogProperties = DialogProperties(),
 ) {
-    Dialog(
-        onDismissRequest = onDismissRequest,
-        properties = properties,
-    ) {
+    val isTest = Build.FINGERPRINT.contains("robolectric", ignoreCase = true)
+
+    val dialogContent = @Composable {
         Column(
             modifier = modifier
                 .fillMaxWidth()
-                .clip(
-                    RoundedCornerShape(
-                        MetaSearchTheme.radius.lg,
-                    ),
-                )
+                .clip(RoundedCornerShape(MetaSearchTheme.radius.lg))
                 .background(White)
                 .border(
                     width = MetaSearchTheme.border.border4,
                     color = LightPink,
-                    shape = RoundedCornerShape(
-                        MetaSearchTheme.radius.lg,
-                    ),
+                    shape = RoundedCornerShape(MetaSearchTheme.radius.lg),
                 )
-                .padding(
-                    MetaSearchTheme.spacing.spacing6,
-                ),
+                .padding(MetaSearchTheme.spacing.spacing6),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             title?.let {
@@ -69,26 +62,15 @@ fun MetaSearchDialog(
                     style = MetaSearchTheme.typography.titleLarge,
                 )
             }
-            Spacer(
-                modifier = Modifier.height(
-                    MetaSearchTheme.spacing.spacing4,
-                ),
-            )
+            Spacer(modifier = Modifier.height(MetaSearchTheme.spacing.spacing4))
             content?.let {
-                Box(
-                    modifier = Modifier.padding(
-                        bottom = MetaSearchTheme.spacing.spacing6,
-                    ),
-                ) {
+                Box(modifier = Modifier.padding(bottom = MetaSearchTheme.spacing.spacing6)) {
                     it()
                 }
             }
-
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(
-                    MetaSearchTheme.spacing.spacing3,
-                ),
+                horizontalArrangement = Arrangement.spacedBy(MetaSearchTheme.spacing.spacing3),
             ) {
                 dismissButtonText?.let {
                     MetaSearchButton(
@@ -98,13 +80,30 @@ fun MetaSearchDialog(
                         contentColor = Neutral500,
                     )
                 }
-
                 MetaSearchButton(
                     modifier = Modifier.weight(1f),
                     text = confirmButtonText,
                     onClick = onConfirmRequest,
                 )
             }
+        }
+    }
+
+    if (isTest) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(MetaSearchTheme.spacing.spacing6),
+            contentAlignment = Alignment.Center,
+        ) {
+            dialogContent()
+        }
+    } else {
+        Dialog(
+            onDismissRequest = onDismissRequest,
+            properties = properties,
+        ) {
+            dialogContent()
         }
     }
 }

--- a/core/ui/src/main/java/com/metasearch/android/core/ui/component/MetaSearchLoadingIndicator.kt
+++ b/core/ui/src/main/java/com/metasearch/android/core/ui/component/MetaSearchLoadingIndicator.kt
@@ -1,5 +1,6 @@
 package com.metasearch.android.core.ui.component
 
+import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -7,6 +8,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.zIndex
 import com.metasearch.android.core.designsystem.annotation.ComponentPreview
 import com.metasearch.android.core.designsystem.theme.Black
@@ -17,6 +19,9 @@ import com.metasearch.android.core.designsystem.theme.Neutral300
 fun MetaSearchLoadingIndicator(
     modifier: Modifier = Modifier,
 ) {
+    val isRobolectric = Build.FINGERPRINT.contains("robolectric", ignoreCase = true)
+    val isInspectionMode = LocalInspectionMode.current
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -24,9 +29,16 @@ fun MetaSearchLoadingIndicator(
             .background(Black.copy(alpha = 0.1f)),
         contentAlignment = Alignment.Center,
     ) {
-        CircularProgressIndicator(
-            color = Neutral300,
-        )
+        if (isInspectionMode || isRobolectric) {
+            CircularProgressIndicator(
+                progress = { 0.75f },
+                color = Neutral300,
+            )
+        } else {
+            CircularProgressIndicator(
+                color = Neutral300,
+            )
+        }
     }
 }
 

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.metasearch.android.feature)
+    alias(libs.plugins.metasearch.test)
 }
 
 android {

--- a/feature/detail/src/main/java/com/metasearch/android/feature/detail/person/PersonDetailUi.kt
+++ b/feature/detail/src/main/java/com/metasearch/android/feature/detail/person/PersonDetailUi.kt
@@ -1,6 +1,8 @@
 package com.metasearch.android.feature.detail.person
 
+import android.os.Build
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -92,7 +94,9 @@ fun PersonDetailUi(
     }
 
     if (state.showPhotoSelectDialog) {
-        Dialog(onDismissRequest = { state.eventSink(PersonDetailUiEvent.OnPhotoSelectCancel) }) {
+        val isTest = Build.FINGERPRINT.contains("robolectric", ignoreCase = true)
+
+        val content = @Composable {
             Surface(
                 shape = RoundedCornerShape(16.dp),
                 color = MaterialTheme.colorScheme.surface,
@@ -125,6 +129,14 @@ fun PersonDetailUi(
                         }
                     }
                 }
+            }
+        }
+
+        if (isTest) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { content() }
+        } else {
+            Dialog(onDismissRequest = { state.eventSink(PersonDetailUiEvent.OnPhotoSelectCancel) }) {
+                content()
             }
         }
     }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.metasearch.android.feature)
+    alias(libs.plugins.metasearch.test)
 }
 
 android {

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.metasearch.android.feature)
+    alias(libs.plugins.metasearch.test)
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ composeStableMarker = "1.0.7"
 constraintlayoutCompose = "1.1.1"
 stabilityAnalyzer = "0.6.4"
 composeEffects = "0.1.4"
+composablePreviewScanner = "0.8.2"
 
 ## Coil
 coilCompose = "3.3.0"
@@ -157,6 +158,7 @@ circuit-test = { module = "com.slack.circuit:circuit-test", version.ref = "circu
 
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
@@ -183,6 +185,9 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
 roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version.ref = "roborazzi" }
+roborazzi-preview-scanner-support = { group = "io.github.takahirom.roborazzi", name = "roborazzi-compose-preview-scanner-support", version.ref = "roborazzi" }
+
+composable-preview-scanner = { group = "io.github.sergio-sastre.ComposablePreviewScanner", name = "android", version.ref = "composablePreviewScanner" }
 
 [bundles]
 androidx-compose = [


### PR DESCRIPTION
## Related issue
- closed #178 

## Work Description ✏️
- Integrate Roborazzi Preview Scanner for automated screenshot testing.
- Wrap MetaSearchTheme with Surface to provide a consistent background for screenshot captures.
- Enable quality checks (Lint/Detekt) for :core:testing module by removing it from skip list.

## Screenshot 📸
<h6>Upload Artifacts</h6>

 [Artifacts](https://github.com/komodgn/meta-android/actions/runs/24606597211)  

<img src="https://github.com/user-attachments/assets/bc4437fc-e793-43bc-b166-4f71250d9e58" width="800"/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated preview screenshot testing for Compose previews.

* **Style**
  * Wrapped app content in a Material3 Surface for more consistent background and theming.

* **Chores**
  * Updated build and dependency configuration to enable preview testing support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->