### PR TITLE
test: Decrease mock photo count to validate Roborazzi diff pipeline

### DIFF
--- a/feature/detail/src/main/java/com/metasearch/android/feature/detail/person/mock/PersonDetailMock.kt
+++ b/feature/detail/src/main/java/com/metasearch/android/feature/detail/person/mock/PersonDetailMock.kt
@@ -5,7 +5,7 @@ import com.metasearch.android.data.domain.fake
 import com.metasearch.android.feature.detail.person.PersonDetailUiState
 import kotlinx.collections.immutable.toPersistentList
 
-internal val fakePhotoUris = (1..28).map { i ->
+internal val fakePhotoUris = (1..27).map { i ->
     "https://picsum.photos/seed/$i/200/200"
 }.toPersistentList()
 


### PR DESCRIPTION
## Related issue
- ~~closed #issue_number~~

## Work Description ✏️
The issue where unchanged screenshots were being reported (46 total) was caused by "polluted artifacts" in the base branch. The fix has been implemented in #186. Instead of merging this PR, the final verification of the cleaned-up pipeline will be conducted through a separate [PR](https://github.com/komodgn/meta-android/pull/187) once the updated CI baseline is established.

## Screenshot 📸
<h6>Expected comments</h6>
<img width="500" alt="com metasearch android feature detail person PersonDetailUiKt_PersonDetailUiEditDialogPreview_compare" src="https://github.com/user-attachments/assets/98e9cf10-b1b1-4b43-9523-3647c4ff8d89" />
<img width="500" alt="com metasearch android feature detail person PersonDetailUiKt_PersonDetailUiPreview_compare" src="https://github.com/user-attachments/assets/fd9d6121-a6f4-4a9e-a336-d0aa49a93660" />
<img width="500" alt="com metasearch android feature detail person PersonDetailUiKt_PersonDetailUiProfileSelectPreview_compare" src="https://github.com/user-attachments/assets/08b30a5c-b54a-4178-bb80-4e3934f7745c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted mock photo dataset size in person detail testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->